### PR TITLE
Fixed logic issue with `light_level` block condition type

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/BlockConditions.java
@@ -3,11 +3,11 @@ package io.github.apace100.apoli.power.factory.condition;
 import io.github.apace100.apoli.Apoli;
 import io.github.apace100.apoli.data.ApoliDataTypes;
 import io.github.apace100.apoli.power.factory.condition.block.CommandCondition;
+import io.github.apace100.apoli.power.factory.condition.block.LightLevelCondition;
 import io.github.apace100.apoli.power.factory.condition.block.MaterialCondition;
 import io.github.apace100.apoli.registry.ApoliRegistries;
 import io.github.apace100.apoli.util.Comparison;
 import io.github.apace100.calio.data.SerializableData;
-import io.github.apace100.calio.data.SerializableDataType;
 import io.github.apace100.calio.data.SerializableDataTypes;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -21,7 +21,6 @@ import net.minecraft.registry.tag.TagKey;
 import net.minecraft.state.property.Property;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
-import net.minecraft.world.LightType;
 
 import java.util.Collection;
 
@@ -97,20 +96,7 @@ public class BlockConditions {
             (data, block) -> block.getBlockState().getBlock() instanceof FluidFillable));
         register(new ConditionFactory<>(Apoli.identifier("exposed_to_sky"), new SerializableData(),
             (data, block) -> block.getWorld().isSkyVisible(block.getBlockPos())));
-        register(new ConditionFactory<>(Apoli.identifier("light_level"), new SerializableData()
-            .add("comparison", ApoliDataTypes.COMPARISON)
-            .add("compare_to", SerializableDataTypes.INT)
-            .add("light_type", SerializableDataType.enumValue(LightType.class), null),
-            (data, block) -> {
-                int value;
-                if(data.isPresent("light_type")) {
-                    LightType lightType = (LightType)data.get("light_type");
-                    value = block.getWorld().getLightLevel(lightType, block.getBlockPos());
-                } else {
-                    value = block.getWorld().getLightLevel(block.getBlockPos());
-                }
-                return ((Comparison)data.get("comparison")).compare(value, data.getInt("compare_to"));
-            }));
+        register(LightLevelCondition.getFactory());
         register(new ConditionFactory<>(Apoli.identifier("block_state"), new SerializableData()
             .add("property", SerializableDataTypes.STRING)
             .add("comparison", ApoliDataTypes.COMPARISON, null)

--- a/src/main/java/io/github/apace100/apoli/power/factory/condition/block/LightLevelCondition.java
+++ b/src/main/java/io/github/apace100/apoli/power/factory/condition/block/LightLevelCondition.java
@@ -1,0 +1,56 @@
+package io.github.apace100.apoli.power.factory.condition.block;
+
+import io.github.apace100.apoli.Apoli;
+import io.github.apace100.apoli.data.ApoliDataTypes;
+import io.github.apace100.apoli.power.factory.condition.ConditionFactory;
+import io.github.apace100.apoli.util.Comparison;
+import io.github.apace100.calio.data.SerializableData;
+import io.github.apace100.calio.data.SerializableDataType;
+import io.github.apace100.calio.data.SerializableDataTypes;
+import net.minecraft.block.pattern.CachedBlockPosition;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.LightType;
+import net.minecraft.world.World;
+
+public class LightLevelCondition {
+
+    public static boolean condition(SerializableData.Instance data, CachedBlockPosition cachedBlock) {
+
+        World world = (World) cachedBlock.getWorld();
+        BlockPos blockPos = cachedBlock.getBlockPos();
+
+        Comparison comparison = data.get("comparison");
+
+        int compareTo = data.getInt("compare_to");
+        int lightLevel;
+
+        if (data.isPresent("light_type")) {
+            lightLevel = world.getLightLevel(data.get("light_type"), blockPos);
+        }
+
+        else {
+
+            if (world.isClient) {
+                world.calculateAmbientDarkness();   //  Re-calculate the world's ambient darkness, since it's only calculated once in the client
+            }
+
+            lightLevel = world.getLightLevel(blockPos);
+
+        }
+
+        return comparison.compare(lightLevel, compareTo);
+
+    }
+
+    public static ConditionFactory<CachedBlockPosition> getFactory() {
+        return new ConditionFactory<>(
+            Apoli.identifier("light_level"),
+            new SerializableData()
+                .add("light_type", SerializableDataType.enumValue(LightType.class), null)
+                .add("comparison", ApoliDataTypes.COMPARISON)
+                .add("compare_to", SerializableDataTypes.INT),
+            LightLevelCondition::condition
+        );
+    }
+
+}


### PR DESCRIPTION
It had the same issue with the `brightness` and `exposed_to_sun` entity condition types, which related to the ambient darkness of the world only being calculated once on the client-side